### PR TITLE
fix: a bug for calculating tree height bug had occurred

### DIFF
--- a/data-structure/tree/balanced_binary_tree/balanced_binary_tree.go
+++ b/data-structure/tree/balanced_binary_tree/balanced_binary_tree.go
@@ -68,7 +68,7 @@ func isBalance(node *Node) bool {
 
 func height(node *Node) int {
 	if node == nil {
-		return 0
+		return -1
 	}
 	return 1 + max(height(node.left), height(node.right))
 }


### PR DESCRIPTION
if binary search tree only has a root node, then the height of the binary search tree is 0.